### PR TITLE
Fix failing tests

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,7 @@
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
+  <test_depend>demo_nodes_py</test_depend>
   <test_depend>launch_ros</test_depend>
   <test_depend>python3-pytest</test_depend>
   <test_depend>ros2launch</test_depend>

--- a/ros2launch_security/node_action/security.py
+++ b/ros2launch_security/node_action/security.py
@@ -24,7 +24,7 @@ from launch.utilities import normalize_to_list_of_substitutions
 from launch_ros.actions.node import Node, NodeActionExtension
 
 import nodl
-import sros2.api._keystore
+import sros2.keystore._enclave
 
 
 class SecurityNodeActionExtension(NodeActionExtension):
@@ -58,7 +58,7 @@ class SecurityNodeActionExtension(NodeActionExtension):
             Node.UNSPECIFIED_NODE_NAME, nodl_node.name
         ).replace(Node.UNSPECIFIED_NODE_NAMESPACE, '')
 
-        sros2.api._keystore.create_enclave(
+        sros2.keystore._enclave.create_enclave(
             keystore_path=pathlib.Path(context.launch_configurations.get('__keystore')),
             identity=self.__enclave
         )

--- a/ros2launch_security/option/security.py
+++ b/ros2launch_security/option/security.py
@@ -21,7 +21,7 @@ from typing import Tuple
 
 import launch
 from ros2launch.option import OptionExtension
-import sros2.api._keystore
+import sros2.keystore._keystore
 
 
 class NoKeystoreProvidedError(Exception):
@@ -122,8 +122,8 @@ class _Keystore:
             if keystore_path is None:
                 raise NoKeystoreProvidedError()
             if not keystore_path.exists():
-                raise NonexistantKeystoreError(keystore_path)
-            if not sros2.api._keystore.is_valid_keystore(keystore_path):
+                raise NonexistentKeystoreError(keystore_path)
+            if not sros2.keystore._keystore.is_valid_keystore(keystore_path):
                 raise InvalidKeystoreError(keystore_path)
 
         # If keystore path is blank, create a transient keystore
@@ -136,8 +136,8 @@ class _Keystore:
         # If keystore is not initialized, create a keystore
         if not self._keystore_path.is_dir():
             self._keystore_path.mkdir()
-        if not sros2.api._keystore.is_valid_keystore(self._keystore_path):
-            sros2.api._keystore.create_keystore(self._keystore_path)
+        if not sros2.keystore._keystore.is_valid_keystore(self._keystore_path):
+            sros2.keystore._keystore.create_keystore(self._keystore_path)
 
     @property
     def path(self) -> pathlib.Path:

--- a/test/test_option.py
+++ b/test/test_option.py
@@ -16,39 +16,40 @@
 """Tests for the launch api."""
 
 import gc
+
 import pytest
 
 from ros2launch_security.option.security import _Keystore
 from ros2launch_security.option.security import InvalidKeystoreError
 from ros2launch_security.option.security import NoKeystoreProvidedError
-from ros2launch_security.option.security import NonexistantKeystoreError
+from ros2launch_security.option.security import NonexistentKeystoreError
 
-import sros2.api._keystore
+import sros2.keystore._keystore
 
 
 @pytest.fixture
 def keystore_path(tmp_path):
-    sros2.api._keystore.create_keystore(tmp_path)
+    sros2.keystore._keystore.create_keystore(tmp_path)
     return tmp_path
 
 
 def test__keystore_existing_keystore(keystore_path):
     res = _Keystore(keystore_path=keystore_path, create_keystore=False)
-    assert sros2.api._keystore.is_valid_keystore(keystore_path)
+    assert sros2.keystore._keystore.is_valid_keystore(keystore_path)
 
     # Test that it doesn't delete a provided keystore when done
     del res
     gc.collect()
-    assert sros2.api._keystore.is_valid_keystore(keystore_path)
+    assert sros2.keystore._keystore.is_valid_keystore(keystore_path)
 
 
 def test__keystore_valid_path_uninitialized_success(tmp_path):
     res = _Keystore(keystore_path=tmp_path, create_keystore=True)
-    assert sros2.api._keystore.is_valid_keystore(tmp_path)
+    assert sros2.keystore._keystore.is_valid_keystore(tmp_path)
 
     del res
     gc.collect()
-    assert sros2.api._keystore.is_valid_keystore(tmp_path)
+    assert sros2.keystore._keystore.is_valid_keystore(tmp_path)
 
 
 def test__keystore_valid_path_uninitialized_fail(tmp_path):
@@ -58,21 +59,21 @@ def test__keystore_valid_path_uninitialized_fail(tmp_path):
 
 def test__keystore_valid_path_nonexistant_success(tmp_path):
     res = _Keystore(keystore_path=tmp_path / 'foo', create_keystore=True)
-    assert sros2.api._keystore.is_valid_keystore(tmp_path / 'foo')
+    assert sros2.keystore._keystore.is_valid_keystore(tmp_path / 'foo')
 
     del res
     gc.collect()
-    assert sros2.api._keystore.is_valid_keystore(tmp_path / 'foo')
+    assert sros2.keystore._keystore.is_valid_keystore(tmp_path / 'foo')
 
 
 def test__keystore_valid_path_nonexistant_fail(tmp_path):
-    with pytest.raises(NonexistantKeystoreError):
+    with pytest.raises(NonexistentKeystoreError):
         _Keystore(keystore_path=tmp_path / 'foo', create_keystore=False)
 
 
 def test__keystore_transient_success():
     res = _Keystore(keystore_path=None, create_keystore=True)
-    assert sros2.api._keystore.is_valid_keystore(res.path)
+    assert sros2.keystore._keystore.is_valid_keystore(res.path)
 
     # Test than keystore is cleaned up correctly
     res = res.path


### PR DESCRIPTION
This patch updates #1 to:
- Target `sros2.keystore._keystore`, not `sros2.api._keystore`
- Target `nodl` module, not `launch_ros.actions.node.nodl`
- Patch `nodl.get_node_by_executable()` properly
- Lookup enclave in `Node.cmd` attribute
- Add `demo_nodes_py` as test dependency
