### PR TITLE
Added enclave check in `_setup_security`

### DIFF
--- a/ros2launch_security/ros2launch_security/node_action/security.py
+++ b/ros2launch_security/ros2launch_security/node_action/security.py
@@ -65,10 +65,13 @@ class SecurityNodeActionExtension(NodeActionExtension):
             Node.UNSPECIFIED_NODE_NAME, nodl_node.name
         ).replace(Node.UNSPECIFIED_NODE_NAMESPACE, '')
 
-        sros2.keystore._enclave.create_enclave(
-            keystore_path=pathlib.Path(context.launch_configurations.get('__keystore')),
-            identity=self.__enclave
-        )
+        # Create an enclave only when it does not exist
+        keystore_path=pathlib.Path(context.launch_configurations.get('__keystore'))
+        if self.__enclave not in sros2.keystore._enclave.get_enclaves(keystore_path):
+            sros2.keystore._enclave.create_enclave(
+                keystore_path=keystore_path,
+                identity=self.__enclave
+            )
 
         ros_specific_arguments['enclave'] = self.__enclave
         return ros_specific_arguments


### PR DESCRIPTION
This PR introduces a check in `ros2launch_security.node_action.security.SecurityNodeActionExtension._setup_security` that ensures an enclave does not already exist before creating it. This is necessary because:

1. It is entirely possible that an enclave was created prior to a `ros2 launch [...] --secure` run.
2. Without checking for a pre-existing run, the `sros2.keystore._enclave.create_enclave` method overwrites any specific `permissions.xml` file with wildcard permissions, which does not work well when integrating with tools like `nodl_to_policy` and `ros2 security create_permissions`, which may have been used earlier either programmatically (`sros2._api._artifact_generation.generate_artifacts`) or through the CLI (`ros2 security create_permission`) to generate desired DDS-specific access permission XML files.

N.B. - This PR will need to be rebased once #4 goes in.

Signed-off-by: Abrar Rahman Protyasha <abrar@openrobotics.org>