### PR TITLE
Integration test with `nodl_to_policy` and middleware-specific XML permissions files

### DIFF
--- a/ros2launch_security_examples/CMakeLists.txt
+++ b/ros2launch_security_examples/CMakeLists.txt
@@ -78,9 +78,19 @@ if(BUILD_TESTING)
       RMW_IMPLEMENTATION=${default_rmw_implementation}
   )
 
+  add_launch_test(
+    "test/test_fake_imu_launch_with_security_nodltopolicy.py"
+    TARGET test_fake_imu_launch_with_security_nodl_to_policy
+    TIMEOUT 60
+    ENV
+      RCL_ASSERT_RMW_ID_MATCHES=${default_rmw_implementation}
+      RMW_IMPLEMENTATION=${default_rmw_implementation}
+  )
+
   set_tests_properties(
     test_fake_imu_launch
     test_fake_imu_launch_with_security
+    test_fake_imu_launch_with_security_nodl_to_policy
     PROPERTIES
       DEPENDS fake_imu
       DEPENDS imu_sink

--- a/ros2launch_security_examples/package.xml
+++ b/ros2launch_security_examples/package.xml
@@ -22,6 +22,9 @@
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
+  <test_depend>nodl_python</test_depend>
+  <test_depend>nodl_to_policy</test_depend>
+  <test_depend>sros2</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/ros2launch_security_examples/test/test_fake_imu_launch_with_security_nodltopolicy.py
+++ b/ros2launch_security_examples/test/test_fake_imu_launch_with_security_nodltopolicy.py
@@ -1,0 +1,130 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from pathlib import Path
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+
+import unittest
+
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess
+from launch.actions import SetEnvironmentVariable
+
+import launch_testing
+import launch_testing_ros
+
+from nodl_python._index import _get_nodes_from_package
+from nodl_to_policy.policy import convert_to_policy
+from sros2.api import _artifact_generation
+from sros2.policy import dump_policy
+
+g_this_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+def create_permissions(keystore_path: Path) -> None:
+    nodl_description = _get_nodes_from_package('ros2launch_security_examples')
+    policy = convert_to_policy(nodl_description)
+    policy_file_path = NamedTemporaryFile().name
+    with open(profile_file_path, 'w') as stream:
+        dump_policy(policy, stream)
+    _artifact_generation.generate_artifacts(
+        keystore_path, [], policy_file_path)
+
+
+def secure_launch_description() -> LaunchDescription:
+    keystore_path = TemporaryDirectory().name
+
+    launch_description = LaunchDescription()
+
+    launch_description.add_action(
+        # bare minimum formatting for console output matching
+        SetEnvironmentVariable('RCUTILS_CONSOLE_OUTPUT_FORMAT', '{message}')
+    )
+    launch_description.add_action(
+        ExecuteProcess(
+            cmd=[
+                # TODO(wjwwood): instead of running `ros2 launch` with the `--secure`
+                #   option, include the launch file normally, e.g. like the
+                #   test_fake_imu_launch.py peer to this test, but this cannot
+                #   be done until we integrate the ros2launch_security plugin
+                #   into `launch_testing`, in addition to `ros2launch`.
+                #   See: https://github.com/osrf/ros2launch_security/issues/5
+                'ros2', 'launch',
+                os.path.join(g_this_dir, '..', 'launch', 'fake_imu.launch.xml'),
+                '--secure', keystore_path,
+            ],
+            name='ros2_launch_fake_imu',
+            output='screen',
+        )
+    )
+
+    create_permissions(Path(keystore_path))
+
+    launch_description.add_action(launch_testing.util.KeepAliveProc())
+    launch_description.add_action(launch_testing.actions.ReadyToTest())
+    return launch_description
+
+
+def generate_test_description():
+    launch_description = secure_launch_description()
+    return launch_description, locals()
+
+
+class TestFakeImuLaunch(unittest.TestCase):
+
+    def test_processes_output(self, proc_output):
+        """Test all processes output against expectations."""
+        # Assumption is that this environment variable is always set by the test runner.
+        rmw_under_test = os.environ['RMW_IMPLEMENTATION']
+        assert rmw_under_test
+
+        from launch_testing.tools.output import get_default_filtered_prefixes
+        output_filter = launch_testing_ros.tools.basic_output_filter(
+            filtered_prefixes=get_default_filtered_prefixes(),
+            filtered_rmw_implementation=rmw_under_test
+        )
+
+        expected_outputs = [
+            # (Process, file containing expected output for the process)
+            # None indicates, any process can produce the output.
+            (None, os.path.join(g_this_dir, 'expected_outputs', 'fake_imu')),
+            (None, os.path.join(g_this_dir, 'expected_outputs', 'imu_sink')),
+            # TODO(wjwwood): right now, looking for the "Found security directory ..."
+            #   messages output anywhere, but it would be better to assert that
+            #   the output is coming from the right processes, but that would
+            #   require figuring out how to integrate the `--secure` option for
+            #   'ros2 launch' into launch_testing.
+            #   See: https://github.com/osrf/ros2launch_security/issues/5
+            (None, os.path.join(g_this_dir, 'expected_outputs', 'enclave_used')),
+        ]
+        for process, expected_output_file in expected_outputs:
+            proc_output.assertWaitFor(
+                process=process,
+                expected_output=launch_testing.tools.expected_output_from_file(
+                    path=expected_output_file
+                ),
+                output_filter=output_filter,
+                timeout=10,
+                # This is needed because ros2 launch channels things to stdout.
+                stream='stdout',
+            )
+
+
+@launch_testing.post_shutdown_test()
+class TestFakeImuLaunchAfterShutdown(unittest.TestCase):
+
+    def test_last_process_exit_code(self, proc_info):
+        """Test last process exit code."""
+        launch_testing.asserts.assertExitCodes(proc_info, process=None)

--- a/ros2launch_security_examples/test/test_fake_imu_launch_with_security_nodltopolicy.py
+++ b/ros2launch_security_examples/test/test_fake_imu_launch_with_security_nodltopolicy.py
@@ -25,7 +25,7 @@ from launch.actions import SetEnvironmentVariable
 import launch_testing
 import launch_testing_ros
 
-from nodl_python._index import _get_nodes_from_package
+from nodl._index import _get_nodes_from_package
 from nodl_to_policy.policy import convert_to_policy
 from sros2.api import _artifact_generation
 from sros2.policy import dump_policy
@@ -34,13 +34,14 @@ g_this_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 def create_permissions(keystore_path: Path) -> None:
-    nodl_description = _get_nodes_from_package('ros2launch_security_examples')
+    nodl_description = _get_nodes_from_package(
+        package_name='ros2launch_security_examples')
     policy = convert_to_policy(nodl_description)
     policy_file_path = NamedTemporaryFile().name
-    with open(profile_file_path, 'w') as stream:
+    with open(policy_file_path, 'w') as stream:
         dump_policy(policy, stream)
     _artifact_generation.generate_artifacts(
-        keystore_path, [], policy_file_path)
+        keystore_path, [], [Path(policy_file_path)])
 
 
 def secure_launch_description() -> LaunchDescription:


### PR DESCRIPTION
This PR introduces a new launch test in `test/test_fake_imu_launch_with_security_nodltopolicy.py`, which serves as an integration test for `ros2launch_security` with the `nodl_to_policy` tool, and shows its use-case in a slightly more complicated example. In a typical "secure" application, `nodl_to_policy` will be called either programmatically or through the CLI after enclave generation. The input will be the NoDL description obtained through `ament_nodl` (or provided manually), and the output will be used to generate middleware-specific permission artifacts in named enclaves (using `sros2`, again either programmatically or through the CLI).

Some things to note:
- This integration test introduces test dependencies on `sros2`, `nodl_to_policy`, and `nodl_python`. If the inclusion of the latter pair is a problem, this test can instead be housed in a separate package.
- The point of this integration test is to show that nodes are well-behaved even when placed under well-formed middleware-specific permissions constraints (as expected). As soon as a topic/service is remapped - say, the topic "imu" is remapped to "not_imu" - the test will fail. This was not the case in `test/test_fake_imu_launch_with_security.py`, which generates wildcard middleware-specific XML permissions files for each enclave. Meaning, as long as the corresponding enclave for a node is present, all topics/services are fair game.
- This PR targets #4. Once that goes into the trunk, this PR will have to be rebased.

Signed-off-by: Abrar Rahman Protyasha <abrar@openrobotics.org>